### PR TITLE
Call Install-PdfInjector in Invoke-PdfInjector

### DIFF
--- a/public/invokePdfInjector.ps1
+++ b/public/invokePdfInjector.ps1
@@ -39,10 +39,12 @@ function Invoke-PdfInjector {
     )
 
     begin{
-        $result = Test-PdfInjector
-        if(! $result){
-            Write-Error "PdfInjector not found"
-            return
+        # Install and Build PdfInjector
+        if(! ( Test-PdfInjector )){
+            if(!( Install-PdfInjector)){
+                Write-Error "PdfInjector not found"
+                return
+            }
         }
     }
 


### PR DESCRIPTION
Calling Install-PdfInjector in Invoke-PdfInjector will avoid third party callers to Install-PdfInjector befor calling it.
The function will take care of initialization if is not done on first call.
